### PR TITLE
Reduce CPU usage

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -11,7 +11,7 @@
 #include "SDL_ttf.h"
 #include "SDL_syswm.h"
 #include "SDL_gfxPrimitives.h"
-#include <time.h>
+#include <sys/time.h>
 #include <string.h>
 #include <string>
 #include <X11/Xlib.h>
@@ -46,10 +46,10 @@ const Uint32 COLOR_FONT = 0xb7b7b7FF;
 const Uint32 COLOR_BACKGROUND = 0x0a0a0a;
 
 Uint32 checkEmit(Uint32 interval, void *param) {
-    time_t rawtime;
+    timeval tv;
     struct tm * time_i;
-    time(&rawtime);
-    time_i = localtime(&rawtime);
+    gettimeofday(&tv, NULL);
+    time_i = localtime(&tv.tv_sec);
 
     if ( time_i->tm_min != past_m) {
         SDL_Event e;
@@ -64,7 +64,7 @@ Uint32 checkEmit(Uint32 interval, void *param) {
 
     // Don't wake up until the next minute.
     Uint32 seconds_to_next_minute = 60 - time_i->tm_sec;
-    interval = seconds_to_next_minute*1000;
+    interval = seconds_to_next_minute*1000 - tv.tv_usec/1000;
     // Make sure interval is positive.
     // Should only matter for leap seconds.
     if ( interval <= 0 ) {

--- a/main.cpp
+++ b/main.cpp
@@ -61,6 +61,15 @@ Uint32 checkEmit(Uint32 interval, void *param) {
         printf("Time is: %d : %d\n", time_i->tm_hour, time_i->tm_min);
         past_m = time_i->tm_min;
     }
+
+    // Don't wake up until the next minute.
+    Uint32 seconds_to_next_minute = 60 - time_i->tm_sec;
+    interval = seconds_to_next_minute*1000;
+    // Make sure interval is positive.
+    // Should only matter for leap seconds.
+    if ( interval <= 0 ) {
+        interval = 500;
+    }
     return (interval);
 }
 int initSDL() {

--- a/main.cpp
+++ b/main.cpp
@@ -316,8 +316,7 @@ int main (int argc, char** argv ) {
     bool done = false;
     while (!done) {
         SDL_Event event;
-	SDL_Delay(300);
-        while (SDL_PollEvent(&event)) {
+        SDL_WaitEvent(&event); {
             switch (event.type) {
             case SDL_USEREVENT:
                 time_t rawTime;

--- a/main.cpp
+++ b/main.cpp
@@ -328,6 +328,7 @@ int main (int argc, char** argv ) {
         SDL_WaitEvent(&event); {
             switch (event.type) {
             case SDL_USEREVENT:
+                SDL_FillRect(screen, 0, SDL_MapRGB(screen->format, 0, 0, 0));
                 time_t rawTime;
                 struct tm * _time;
                 time(&rawTime);
@@ -348,7 +349,6 @@ int main (int argc, char** argv ) {
                 break;
             }
         }
-        SDL_FillRect(screen, 0, SDL_MapRGB(screen->format, 0, 0, 0));
     }
     SDL_FreeSurface(screen);
     TTF_CloseFont(FONT_TIME);


### PR DESCRIPTION
Reduce CPU usage by using SDL's timers to only wake up once per minute. Less hackish and more efficient than adding an extra `SDL_Delay` as the current code does.

Closes #3.